### PR TITLE
Update Droid CUA docs from feedback

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -3,11 +3,6 @@
 ## Introduction
 
 * [Loadmill - AI - Powered Solution](README.md)
-* [Droid CUA](droid-cua/README.md)
-  * [Getting Started](droid-cua/getting-started.md)
-  * [Setup](droid-cua/setup.md)
-    * [Setup Troubleshooting](droid-cua/setup-troubleshooting.md)
-  * [CLI](droid-cua/cli.md)
 * [Deviceless mobile testing](introduction/deviceless-mobile-testing/README.md)
   * [Capturing traffic with Loadmill MITM Proxy](introduction/deviceless-mobile-testing/capturing-traffic-with-loadmill-mitm-proxy.md)
   * [Installing Loadmill desktop app](introduction/deviceless-mobile-testing/installing-loadmill-desktop-app/README.md)
@@ -28,6 +23,14 @@
 * [API Server Testing](introduction/api-server-testing/README.md)
   * [Contract testing](introduction/api-server-testing/contract-testing.md)
   * [Regression Testing](introduction/api-server-testing/regression-testing.md)
+
+## Droid CUA
+
+* [Overview](droid-cua/README.md)
+* [Getting Started](droid-cua/getting-started.md)
+* [Setup](droid-cua/setup.md)
+  * [Setup Troubleshooting](droid-cua/setup-troubleshooting.md)
+* [CLI](droid-cua/cli.md)
 
 ## Quick Guide
 

--- a/droid-cua/README.md
+++ b/droid-cua/README.md
@@ -1,15 +1,13 @@
 # Droid CUA
 
-Droid CUA is Loadmill's AI-powered desktop app for mobile testing.
+Droid CUA is Loadmill's AI-powered desktop app for mobile and web testing.
 
-It helps you create, run, and manage tests for Android devices and emulators, and for iOS simulators on macOS. Instead of writing traditional mobile automation code with selectors and locators, you describe the user flow in natural language and let the agent operate the app from the screen, the same way a person would.
-
-<video controls width="100%" src="../assets/cua-demo.mov" title="Droid CUA demo"></video>
+It helps you create, run, and manage tests for Android devices and emulators, iOS simulators on macOS, cloud mobile devices, and browser flows. Instead of writing traditional automation code with selectors and locators, you describe the user flow in natural language and let the agent operate the app from the screen, the same way a person would.
 
 With Droid CUA you can:
 
-* Connect to a real Android device, Android emulator, or iOS simulator.
-* Create mobile tests from plain-English instructions.
+* Connect to a real Android device, Android emulator, iOS simulator, cloud mobile device, or browser.
+* Create mobile and web tests from plain-English instructions.
 * Watch the agent execute each action with live logs.
 * Save reusable `.dcua` test scripts.
 * Run saved tests again from the desktop app or the CLI.
@@ -27,7 +25,7 @@ The result is a test workflow that is easier to draft, easier to understand, and
 
 ***
 
-## What you can test
+## Platforms
 
 ### Android
 
@@ -37,14 +35,22 @@ Droid CUA supports physical Android devices and Android emulators.
 
 Droid CUA supports iOS simulators on macOS.
 
+### Web
+
+Droid CUA supports browser testing with installed Chrome or Edge.
+
+### Cloud devices
+
+Droid CUA supports cloud mobile runs on LambdaTest from the CLI. Cloud runs use real Android or iOS devices and require your LambdaTest credentials plus an app build.
+
 ### Desktop support
 
-* macOS: Android and iOS simulator workflows
-* Windows: Android workflows
+* macOS: Android, iOS simulator, and web workflows
+* Windows: Android and web workflows
 
 ***
 
 ## Learn more
 
 * [Getting started](getting-started.md)
-* [CLI basics](cli.md)
+* [CLI](cli.md)

--- a/droid-cua/cli.md
+++ b/droid-cua/cli.md
@@ -1,6 +1,6 @@
 # Droid CUA CLI
 
-The Droid CUA desktop app is the main place to create and debug tests. The CLI lets you run saved `.dcua` tests from a terminal, CI pipeline, or other automation workflow.
+The Droid CUA desktop app is the main place to create and debug tests. The CLI lets you run saved `.dcua` tests from a terminal, CI pipeline, or other automation workflow across mobile, cloud device, and web targets.
 
 ***
 
@@ -46,6 +46,43 @@ droid-cua --platform ios --avd "iPhone 16" --instructions tests/login.dcua
 
 ***
 
+## Run a saved web test
+
+Use `--target web` to run a `.dcua` test against an installed browser.
+
+```sh
+droid-cua --target web --browser chrome --instructions tests/search.dcua
+```
+
+Supported browser values are `chrome` and `edge`.
+
+***
+
+## Run on a LambdaTest cloud device
+
+Set your LambdaTest credentials:
+
+```sh
+export LAMBDATEST_USERNAME=your-username
+export LAMBDATEST_ACCESS_KEY=your-access-key
+```
+
+Then run with `--device-source lambdatest` and pass the target device details.
+
+```sh
+droid-cua \
+  --device-source lambdatest \
+  --platform android \
+  --device-name "Galaxy S24" \
+  --os-version "14" \
+  --app ./app-debug.apk \
+  --instructions tests/login.dcua
+```
+
+Android cloud runs require an `.apk` file. iOS cloud runs require an `.ipa` file.
+
+***
+
 ## Use a config file
 
 For CI, it is recommended to keep a small JSON config file in the repository and run tests with `--config`.
@@ -83,9 +120,15 @@ The config file keeps prompt settings and app context consistent between local r
 
 | Option | Description |
 | --- | --- |
+| `--target` | Target kind, such as `mobile` or `web`. |
 | `--instructions` | Path to a `.dcua` test file or a folder of `.dcua` files. |
 | `--avd` | Android device, Android emulator, or iOS simulator name. |
 | `--platform` | Target platform, such as `android` or `ios`. |
+| `--browser` | Browser for web runs, such as `chrome` or `edge`. |
+| `--device-source` | Mobile device source, such as `local` or `lambdatest`. |
+| `--device-name` | LambdaTest cloud device name. |
+| `--os-version` | LambdaTest cloud device OS version. |
+| `--app` | App build path for LambdaTest runs. Use `.apk` for Android or `.ipa` for iOS. |
 | `--config` | Path to a Droid CUA headless config file. |
 | `--cua-model` | Model to use for the run. |
 | `--context` | Path to an app context file. |
@@ -115,8 +158,6 @@ jobs:
             --instructions tests/login.dcua \
             --config ci/droid-cua.json \
             --debug
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
 A successful run exits with code `0`. A failed run exits with code `1`, so CI can fail the build when the mobile test fails.

--- a/droid-cua/getting-started.md
+++ b/droid-cua/getting-started.md
@@ -9,10 +9,11 @@ This guide shows the basic path for running your first Droid CUA test.
 You will need:
 
 * The Droid CUA desktop app installed.
-* A Loadmill account or an OpenAI API key.
-* A target device or simulator.
+* A Loadmill account.
+* A target device, simulator, cloud device, or browser.
 * Android Debug Bridge (ADB) for Android testing.
 * Xcode, Appium, and the XCUITest driver for iOS simulator testing on macOS.
+* Chrome or Edge installed for web testing.
 
 For a fuller checklist, see [Setup](setup.md).
 
@@ -30,21 +31,25 @@ After the download finishes, install and launch Droid CUA.
 
 ***
 
-## Step 2: Sign in or add your API key
+## Step 2: Sign in
 
-When the app opens, sign in with your Loadmill account or open **Settings** and add your OpenAI API key.
+When the app opens, sign in with your Loadmill account.
 
 If the setup wizard appears, follow the checks it shows. It helps confirm that the required tools for Android or iOS testing are installed.
 
 ***
 
-## Step 3: Connect a device
+## Step 3: Choose a target
 
 Choose the platform you want to test.
 
 For Android, connect a physical device with USB debugging enabled, or choose an available emulator.
 
 For iOS, choose an installed iOS simulator. iOS simulator testing is available on macOS only.
+
+For web testing, choose the web platform and use an installed Chrome or Edge browser.
+
+For cloud mobile testing, use the CLI with LambdaTest credentials and a mobile app build.
 
 ![Droid CUA device selection screen](../assets/devices-page.png)
 

--- a/droid-cua/setup-troubleshooting.md
+++ b/droid-cua/setup-troubleshooting.md
@@ -60,17 +60,34 @@ After installing missing tools, restart Droid CUA and open the device picker aga
 
 ***
 
-## OpenAI API key is missing or rejected
+## Web browser is not found
 
-Open **Settings** in Droid CUA and confirm that your API key is set correctly.
+For web tests, install Google Chrome or Microsoft Edge and restart Droid CUA.
 
-For CLI runs, make sure `OPENAI_API_KEY` is available in the shell or CI environment.
+For CLI runs, confirm the selected browser is supported:
 
 ```sh
-export OPENAI_API_KEY=your-api-key
+droid-cua --target web --browser chrome --instructions tests/search.dcua
 ```
 
-Then run the test again.
+Use `--browser edge` if you want to run against Microsoft Edge.
+
+***
+
+## LambdaTest cloud device run fails before connecting
+
+Check that the required LambdaTest inputs are set:
+
+* `LAMBDATEST_USERNAME`
+* `LAMBDATEST_ACCESS_KEY`
+* `--device-source lambdatest`
+* `--platform android` or `--platform ios`
+* `--device-name`
+* `--os-version`
+* `--app`
+* `--instructions`
+
+Android cloud runs require an `.apk` file. iOS cloud runs require an `.ipa` file.
 
 ***
 
@@ -93,8 +110,8 @@ Check the most common inputs:
 * `--instructions` points to an existing `.dcua` file or folder.
 * `--avd` matches the selected Android device, emulator, or iOS simulator.
 * `--platform ios` is used for iOS simulator runs.
+* `--target web` is used for browser runs.
 * `--config` points to valid JSON.
-* `OPENAI_API_KEY` is available in the environment.
 
 Run with `--debug` to create detailed artifacts for troubleshooting:
 

--- a/droid-cua/setup.md
+++ b/droid-cua/setup.md
@@ -1,6 +1,6 @@
 # Setup
 
-This page covers the basic setup required before running Droid CUA tests.
+This page covers the basic setup required before running Droid CUA tests on mobile devices, cloud devices, and browsers.
 
 ***
 
@@ -12,7 +12,7 @@ Download and install the Droid CUA desktop app:
 * [Mac Intel](https://github.com/loadmill/droid-cua-release/releases/latest/download/Loadmill-Droid-CUA-intel.dmg)
 * [Windows](https://github.com/loadmill/droid-cua-release/releases/latest/download/Loadmill-Droid-CUA-Setup.exe)
 
-After installation, launch Droid CUA and sign in with your Loadmill account or add your OpenAI API key in **Settings**.
+After installation, launch Droid CUA and sign in with your Loadmill account.
 
 When you open Droid CUA for the first time, the setup wizard helps you choose a platform and run the required checks.
 
@@ -64,6 +64,46 @@ Install and configure:
 After setup, open Droid CUA and choose an installed simulator from the device picker.
 
 Use the platform selector on the **Devices** page to switch between Android, iOS, and web targets.
+
+***
+
+## Web setup
+
+To test web flows, install a supported browser:
+
+* Google Chrome
+* Microsoft Edge
+
+Droid CUA uses Playwright with the installed browser for web execution. In the CLI, use `--target web` with `--instructions`.
+
+```sh
+droid-cua --target web --browser chrome --instructions tests/search.dcua
+```
+
+Use `--browser edge` to run against Microsoft Edge.
+
+***
+
+## Cloud device setup
+
+Droid CUA supports cloud mobile runs on LambdaTest from the CLI.
+
+You will need:
+
+* `LAMBDATEST_USERNAME`
+* `LAMBDATEST_ACCESS_KEY`
+* A target platform, such as `android` or `ios`
+* A cloud device name and OS version
+* An app build: `.apk` for Android or `.ipa` for iOS
+
+Set the credentials in your shell or CI environment:
+
+```sh
+export LAMBDATEST_USERNAME=your-username
+export LAMBDATEST_ACCESS_KEY=your-access-key
+```
+
+Then run Droid CUA with `--device-source lambdatest`.
 
 ***
 


### PR DESCRIPTION
## Summary
- Add web/browser and LambdaTest cloud-device coverage to the Droid CUA overview, setup, troubleshooting, and CLI docs
- Clarify that users only need a Loadmill account/login in the docs and remove OpenAI API key setup guidance
- Move Droid CUA into its own top-level navigation section between Introduction and Quick Guide
- Remove the broken demo video embed and delete the unused video asset

## Checks
- Ran `git diff --check`
- Scanned Droid CUA docs for leftover OpenAI API key/video references and sensitive-looking values